### PR TITLE
ci: prepare publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,7 +5,7 @@ on:
   release:
     types: [published]
     tags-ignore:
-      - blossom-js-lib*
+      - blossom-lib*
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release-please-lib.yaml
+++ b/.github/workflows/release-please-lib.yaml
@@ -17,8 +17,8 @@ jobs:
         with:
           release-type: node
           path: library
-          package-name: 'blossom-js-lib'
+          package-name: 'blossom-lib'
           changelog-path: 'library/CHANGELOG.md'
           version-file: 'library/package.json'
-          pull-request-title-pattern: 'chore${scope}: release js-lib ${version}'
+          pull-request-title-pattern: 'chore${scope}: release blossom-lib ${version}'
           monorepo-tags: true

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -12,9 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: google-github-actions/release-please-action@v3
-        id: release
+        id: release-ext
         with:
+          token: ${{ secrets.REPO_GHA_PAT }}
           release-type: node
           package-name: 'blossom-ext'
-          pull-request-title-pattern: 'chore${scope}: release blossom ${version}'
+          pull-request-title-pattern: 'chore${scope}: release blossom-ext ${version}'
           monorepo-tags: true


### PR DESCRIPTION
- renaming job ids to more consistent ids
- use `secrets.REPO_GHA_PAT` as token in `release-please` actions

Resolves: #47