### PR TITLE
fix: several library fixes (#56, #57)

### DIFF
--- a/library/src/blossom.ts
+++ b/library/src/blossom.ts
@@ -3,6 +3,7 @@ import { ApiActions } from './constants/api-actions.enum'
 import { BlossomMessages } from './messages/blossom-messages'
 import { createBlossomMessages } from './messages/blossom-messages.factory'
 import createFdpStorageProxy from './proxy/fdp-storage.proxy.factory'
+import { getDappId } from './utils/dapp.util'
 
 /**
  * Interface of the Blossom browser extension
@@ -18,6 +19,11 @@ export class Blossom {
    * https://github.com/fairDataSociety/fdp-storage#usage
    */
   public readonly fdpStorage: FdpStorage
+
+  /**
+   * dApp ENS name. If dApp is loaded from an invalid URL, the value will be null.
+   */
+  public readonly dappId: string | null = getDappId()
 
   /**
    *

--- a/library/src/utils/dapp.util.ts
+++ b/library/src/utils/dapp.util.ts
@@ -1,0 +1,14 @@
+const dappIdRegex = new RegExp('.+/bzz/([^/]+).*')
+
+export function getDappId(): string | null {
+  const url = window.location.href
+
+  // extracts dApp ENS name from a bzz link (e.g http://127.0.0.1:1633/bzz/ENS/...)
+  const result = dappIdRegex.exec(url)
+
+  if (!result || !result[1]) {
+    return null
+  }
+
+  return result[1]
+}

--- a/library/src/utils/window.util.ts
+++ b/library/src/utils/window.util.ts
@@ -1,0 +1,8 @@
+export function getOnDocumentReadyPromise(): Promise<void> {
+  return new Promise(resolve => {
+    if (document.readyState == 'complete') {
+      return resolve()
+    }
+    window.addEventListener('load', () => resolve())
+  })
+}

--- a/src/services/fdp-storage/fdp-storage-access.ts
+++ b/src/services/fdp-storage/fdp-storage-access.ts
@@ -22,15 +22,15 @@ function personalStorageHandler(
 ) {
   parameters.shift()
 
-  return personalStorage[method](dappIdToPodName(dappId), parameters)
+  return personalStorage[method](dappIdToPodName(dappId), ...parameters)
 }
 
 function directoryHandler(directory: Directory, method: string, parameters: unknown[]) {
-  return directory[method](parameters)
+  return directory[method](...parameters)
 }
 
 function fileHandler(file: File, method: string, parameters: unknown[]) {
-  return file[method](parameters)
+  return file[method](...parameters)
 }
 
 const proxy: Record<string, FdpStorageProxy> = {

--- a/src/services/fdp-storage/fdp-storage.utils.ts
+++ b/src/services/fdp-storage/fdp-storage.utils.ts
@@ -6,7 +6,7 @@ export function dappUrlToId(url: string, beeUrl: string): DappId {
 
   const bzzUrl = beeUrl + (beeUrl.endsWith('/') ? '' : '/') + 'bzz/'
 
-  // extracts dApp ENS from a bzz link (e.g http://127.0.0.1:1633/bzz/ENS/...)
+  // extracts dApp ENS name from a bzz link (e.g http://127.0.0.1:1633/bzz/ENS/...)
   const result = new RegExp(`${bzzUrl}([^/]+).*`).exec(url)
 
   if (!result || !result[1]) {


### PR DESCRIPTION
If a request is triggered before the content script is initialized, the library will block the request until page loads. Also the `dappId` property has been added to the `Blossom` class. But if dapp is loaded from a none-bzz link, it will be null.
closes #56, closes #57