### PR TITLE
ci: add bump minor pre major config

### DIFF
--- a/.github/workflows/release-please-lib.yaml
+++ b/.github/workflows/release-please-lib.yaml
@@ -22,3 +22,4 @@ jobs:
           version-file: 'library/package.json'
           pull-request-title-pattern: 'chore${scope}: release blossom-lib ${version}'
           monorepo-tags: true
+          bump-minor-pre-major: true

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -19,3 +19,4 @@ jobs:
           package-name: 'blossom-ext'
           pull-request-title-pattern: 'chore${scope}: release blossom-ext ${version}'
           monorepo-tags: true
+          bump-minor-pre-major: true


### PR DESCRIPTION
we are going to release `0.1.0` for first version of the extension and its library.

Until 1.0.0 we will have braking changes in minor versions. This PR configures release-please CI actions according to that.