### PR TITLE
feat: add whitelisted dapps

### DIFF
--- a/src/constants/whitelisted-dapps.ts
+++ b/src/constants/whitelisted-dapps.ts
@@ -12,5 +12,4 @@ export const whitelistedDapps: Array<{ url: string; dappId: string }> = [
   { url: 'https://fairdrive.fairdatasociety.org/apps/dracula', dappId: 'dracula' },
   { url: 'https://fairdrive.dev.fairdatasociety.org/apps/slidezz', dappId: 'slidezz-dev' },
   { url: 'https://fairdrive.fairdatasociety.org/apps/slidezz', dappId: 'slidezz' },
-  { url: 'http://localhost:3000', dappId: 'fairdrive' },
 ]

--- a/src/constants/whitelisted-dapps.ts
+++ b/src/constants/whitelisted-dapps.ts
@@ -1,0 +1,16 @@
+// Maps whitelisted dapps to their ENS names
+export const whitelistedDapps: Array<{ url: string; dappId: string }> = [
+  { url: 'https://fairdrive.dev.fairdatasociety.org', dappId: 'fairdrive-dev' },
+  { url: 'https://fairdrive.fairdatasociety.org', dappId: 'fairdrive' },
+  { url: 'https://fairdrive.dev.fairdatasociety.org/apps/consents', dappId: 'consents-dev' },
+  { url: 'https://fairdrive.fairdatasociety.org/apps/consents', dappId: 'consents' },
+  { url: 'https://app.photo.dev.fairdatasociety.org', dappId: 'photo-album-dev' },
+  { url: 'https://app.photo.fairdatasociety.org', dappId: 'photo-album' },
+  { url: 'https://app.dracula.dev.fairdatasociety.org', dappId: 'dracula-dev' },
+  { url: 'https://app.dracula.fairdatasociety.org', dappId: 'dracula' },
+  { url: 'https://fairdrive.dev.fairdatasociety.org/apps/dracula', dappId: 'dracula-dev' },
+  { url: 'https://fairdrive.fairdatasociety.org/apps/dracula', dappId: 'dracula' },
+  { url: 'https://fairdrive.dev.fairdatasociety.org/apps/slidezz', dappId: 'slidezz-dev' },
+  { url: 'https://fairdrive.fairdatasociety.org/apps/slidezz', dappId: 'slidezz' },
+  { url: 'http://localhost:3000', dappId: 'fairdrive' },
+]

--- a/src/services/fdp-storage/fdp-storage.utils.ts
+++ b/src/services/fdp-storage/fdp-storage.utils.ts
@@ -35,19 +35,13 @@ function extractDappIdFromWhitelistedDapps(url: string): string | undefined {
 }
 
 function isDappIdForged(dappId: string, url: string): boolean {
-  let isWhitelistedDappId = false
+  const whitelistedDapp = whitelistedDapps.find(({ dappId: currentDappId }) => currentDappId === dappId)
 
-  const matchingUrl = whitelistedDapps.some(({ url: currentUrl, dappId: currentDappId }) => {
-    if (currentDappId === dappId) {
-      isWhitelistedDappId = true
-
-      return url.startsWith(currentUrl)
-    }
-
+  if (!whitelistedDapp) {
     return false
-  })
+  }
 
-  return isWhitelistedDappId && !matchingUrl
+  return !url.startsWith(whitelistedDapp.url)
 }
 
 export function dappUrlToId(url: string, beeUrl: string): DappId {


### PR DESCRIPTION
Blossom only supports dApps that are loaded from bee URL. But we have dApps that are hosted on other domains. Such applications can't work because they don't have a valid dappId. This update will solve that issue.