### PR TITLE
feat: add global errors

### DIFF
--- a/assets/locales/en-US.json
+++ b/assets/locales/en-US.json
@@ -77,5 +77,6 @@
   "ACCESS": "Access",
   "DISCLAIMER": "Disclaimer: Account integrity persistence and security are not assured. Expect that funds used for account might be lost, as well as any data the account uses.",
   "DAPP_SIGN_MESSAGE_MESSAGE": "Dapp with ID {dappId} wants to sign the following message: {message}. Do you want to sign the message?",
-  "EXTENSION_SIGN_MESSAGE_MESSAGE": "Extension with ID {dappId} wants to sign the following message: {message}. Do you want to sign the message?"
+  "EXTENSION_SIGN_MESSAGE_MESSAGE": "Extension with ID {dappId} wants to sign the following message: {message}. Do you want to sign the message?",
+  "ERROR_USER_NOT_LOGGED_IN": "User is not logged in"
 }

--- a/src/constants/background-actions.enum.ts
+++ b/src/constants/background-actions.enum.ts
@@ -26,6 +26,7 @@ enum BackgroundAction {
   GET_ALL_DAPP_IDS = 'get-all-dapp-ids',
   GET_DAPP_SETTINGS = 'get-dapp-settings',
   UPDATE_DAPP_SETTINGS = 'update-dapp-settings',
+  GET_ERROR = 'get-error',
   ECHO = 'echo',
 }
 

--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -1,0 +1,13 @@
+import { ErrorObject } from '../model/error.model'
+
+export enum ErrorCode {
+  USER_NOT_LOGGED_IN,
+}
+
+export const errors: Record<ErrorCode, ErrorObject> = {
+  [ErrorCode.USER_NOT_LOGGED_IN]: {
+    code: ErrorCode.USER_NOT_LOGGED_IN,
+    priority: 2,
+    message: 'ERROR_USER_NOT_LOGGED_IN',
+  },
+}

--- a/src/listeners/message-listeners/general.listener.ts
+++ b/src/listeners/message-listeners/general.listener.ts
@@ -1,0 +1,20 @@
+import BackgroundAction from '../../constants/background-actions.enum'
+import { Errors } from '../../services/error.service'
+import { createMessageHandler } from './message-handler'
+
+const errors = new Errors()
+
+export async function getLastError(): Promise<string> {
+  const errorMessage = await errors.getMostImportantMessage()
+
+  return errorMessage
+}
+
+const messageHandler = createMessageHandler([
+  {
+    action: BackgroundAction.GET_ERROR,
+    handler: getLastError,
+  },
+])
+
+export default messageHandler

--- a/src/listeners/message-listeners/index.ts
+++ b/src/listeners/message-listeners/index.ts
@@ -5,12 +5,13 @@ import locales from './locales.listener'
 import account from './account.listener'
 import settings from './settings.listener'
 import signer from './signer.listener'
+import general from './general.listener'
 import test from './test.listener'
 import { isInternalMessage, isOtherExtension } from '../../utils/extension'
 import { DAPP_ACTIONS, E2E_ACTIONS } from '../../constants/dapp-actions.enum'
 import BackgroundAction from '../../constants/background-actions.enum'
 
-const listenrs = [auth, fdpStorage, locales, account, settings, signer, test]
+const listenrs = [auth, fdpStorage, locales, account, settings, signer, general, test]
 
 export function messageHandler(
   message: Message<unknown>,

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,11 +2,12 @@ import './listeners'
 import { SessionService } from './services/session.service'
 import './services/update.service'
 import './live-reload'
+import { Errors } from './services/error.service'
 
 //eslint-disable-next-line @typescript-eslint/no-unused-vars
 const session = new SessionService()
+const errors = new Errors()
 
-try {
-  session.load()
-  // eslint-disable-next-line no-empty
-} catch (error) {}
+;(async () => {
+  await Promise.all([session.load(), errors.refreshGlobalError()])
+})()

--- a/src/messaging/content-api.messaging.ts
+++ b/src/messaging/content-api.messaging.ts
@@ -108,6 +108,10 @@ export function updateDappSettings(dapp: Dapp): Promise<void> {
   return sendMessage<Dapp, void>(BackgroundAction.UPDATE_DAPP_SETTINGS, dapp)
 }
 
+export function getGlobalError(): Promise<string> {
+  return sendMessage<void, string>(BackgroundAction.GET_ERROR)
+}
+
 export function echo<Data>(data: Data): Promise<Data> {
   return sendMessage<Data, Data>(BackgroundAction.ECHO, data)
 }

--- a/src/model/error.model.ts
+++ b/src/model/error.model.ts
@@ -1,0 +1,7 @@
+import { ErrorCode } from '../constants/errors'
+
+export interface ErrorObject {
+  code: ErrorCode
+  priority: number
+  message: string
+}

--- a/src/model/storage/general.model.ts
+++ b/src/model/storage/general.model.ts
@@ -1,0 +1,8 @@
+import { ErrorCode } from '../../constants/errors'
+import { ErrorObject } from '../error.model'
+
+export type Errors = Partial<Record<ErrorCode, ErrorObject>>
+
+export interface General {
+  errors: Errors
+}

--- a/src/services/error.service.ts
+++ b/src/services/error.service.ts
@@ -1,0 +1,69 @@
+import { ErrorCode, errors as globalErrors } from '../constants/errors'
+import { ErrorObject } from '../model/error.model'
+import { removeWarningBadge, setWarningBadge } from '../utils/extension'
+import { Storage } from './storage/storage.service'
+import { Errors as ErrorsModel } from '../model/storage/general.model'
+import { Locales } from './locales.service'
+
+export class Errors {
+  private storage: Storage = new Storage()
+
+  public async refreshGlobalError() {
+    const errors = await this.getErrors()
+
+    ;(this.hasErrors(errors) ? setWarningBadge : removeWarningBadge)()
+  }
+
+  public async getMostImportantMessage(): Promise<string | null> {
+    const errors = await this.getErrors()
+
+    const mostImportantError = Object.values(errors).reduce(
+      (mostImportantError, currentError) => {
+        return mostImportantError.priority < currentError.priority ? mostImportantError : currentError
+      },
+      { priority: 100 } as ErrorObject,
+    )
+
+    return mostImportantError ? mostImportantError.message : null
+  }
+
+  public async addGlobalError(errorCode: ErrorCode): Promise<ErrorObject> {
+    const errors = await this.getErrors()
+
+    const error = { ...globalErrors[errorCode] }
+
+    errors[errorCode] = error
+
+    await this.updateErrors(errors)
+
+    setWarningBadge()
+
+    return error
+  }
+
+  public async removeGlobalError(errorCode: ErrorCode) {
+    const errors = await this.getErrors()
+
+    delete errors[errorCode]
+
+    await this.updateErrors(errors)
+
+    if (this.hasErrors(errors)) {
+      removeWarningBadge()
+    }
+  }
+
+  private hasErrors(errors: ErrorsModel): boolean {
+    return errors && Object.keys(errors).length === 0
+  }
+
+  private async getErrors(): Promise<ErrorsModel> {
+    const { errors } = await this.storage.getGeneral()
+
+    return errors
+  }
+
+  private updateErrors(errors: ErrorsModel): Promise<void> {
+    return this.storage.updateGeneral({ errors })
+  }
+}

--- a/src/services/storage/storage-factories.ts
+++ b/src/services/storage/storage-factories.ts
@@ -5,6 +5,7 @@ import { StorageSession } from '../../model/storage/session.model'
 import { AccountDapps, Dapp, Dapps } from '../../model/storage/dapps.model'
 import { Accounts } from '../../model/storage/account.model'
 import { DappId } from '../../model/general.types'
+import { General } from '../../model/storage/general.model'
 
 export function networkFactory(): Network {
   return { ...networks[0] }
@@ -45,4 +46,10 @@ export function dappFactory(dappId: DappId): Dapp {
 
 export function accountsFactory(): Accounts {
   return {}
+}
+
+export function generalFactory(): General {
+  return {
+    errors: {},
+  }
 }

--- a/src/services/storage/storage.service.ts
+++ b/src/services/storage/storage.service.ts
@@ -11,10 +11,12 @@ import {
   accountsFactory,
   dappFactory,
   accountDappsFactory,
+  generalFactory,
 } from './storage-factories'
 import { DappId } from '../../model/general.types'
 import { AccountDapps, Dapp, Dapps, PodPermission } from '../../model/storage/dapps.model'
 import { StorageAccount, Accounts } from '../../model/storage/account.model'
+import { General } from '../../model/storage/general.model'
 
 /**
  * Sets any value to the extension storage
@@ -118,6 +120,7 @@ export class Storage {
   static readonly dappsKey = 'dapps'
   static readonly accountsKey = 'accounts'
   static readonly storageVersion = 'storage-version'
+  static readonly generalKey = 'general'
 
   constructor() {
     chrome.storage.onChanged.addListener(this.onChangeListener.bind(this))
@@ -298,6 +301,14 @@ export class Storage {
 
   public deleteAccounts(): Promise<void> {
     return deleteEntry(Storage.accountsKey)
+  }
+
+  public updateGeneral(data: Partial<General>): Promise<void> {
+    return updateObject(Storage.generalKey, data)
+  }
+
+  public getGeneral(): Promise<General> {
+    return getObject(Storage.generalKey, generalFactory)
   }
 
   public onNetworkChange(listener: (network: Network) => void) {

--- a/src/ui/settings/pages/main/main.tsx
+++ b/src/ui/settings/pages/main/main.tsx
@@ -8,26 +8,40 @@ import Security from '@mui/icons-material/Security'
 import Section from './section.component'
 import { useNavigate } from 'react-router-dom'
 import RouteCodes from '../../routes/route-codes'
-import { getCurrentUser, logout, openAuthPage } from '../../../../messaging/content-api.messaging'
+import {
+  getCurrentUser,
+  getGlobalError,
+  logout,
+  openAuthPage,
+} from '../../../../messaging/content-api.messaging'
 import { UserResponse } from '../../../../model/internal-messages.model'
 import UserInfo from './user-info.component'
+import ErrorMessage from '../../../common/components/error-message/error-message.component'
 
 const Main = () => {
   const navigate = useNavigate()
   const [user, setUser] = useState<UserResponse>(null)
+  const [globalError, setGlobalError] = useState<string | undefined>(undefined)
 
-  const loadUser = async () => {
-    const user = await getCurrentUser()
+  const loadData = async () => {
+    const [user, globalError] = await Promise.all([getCurrentUser(), getGlobalError()])
+
     setUser(user)
+    setGlobalError(globalError)
+  }
+
+  const onLoginOrRegister = async () => {
+    await openAuthPage()
+    loadData()
   }
 
   const onLogout = async () => {
     await logout()
-    setUser(null)
+    loadData()
   }
 
   useEffect(() => {
-    loadUser()
+    loadData()
   }, [])
 
   return (
@@ -35,6 +49,7 @@ const Main = () => {
       <Typography variant="h5" align="center">
         Blossom
       </Typography>
+      {globalError && <ErrorMessage>{intl.get(globalError)}</ErrorMessage>}
       <Stack spacing={3} sx={{ paddingTop: '20px' }}>
         {user ? (
           <UserInfo user={user} onLogout={onLogout} />
@@ -42,7 +57,7 @@ const Main = () => {
           <Section
             description={intl.get('LOGIN_REGISTER_DESCRIPTION')}
             image={<VpnKey />}
-            onClick={openAuthPage}
+            onClick={onLoginOrRegister}
             dataTestId="settings-registration-login"
           >
             {intl.get('LOGIN_OR_REGISTER')}

--- a/test/registration.spec.ts
+++ b/test/registration.spec.ts
@@ -14,6 +14,7 @@ import {
   dataTestId,
   getElementByTestId,
   isElementDisabled,
+  wait,
   waitForElementText,
   waitForElementTextByTestId,
 } from './test-utils/page'
@@ -168,7 +169,10 @@ describe('Login tests', () => {
 
   test('Should login with valid credentials', async () => {
     await page.reload()
+
     await fillUsernamePasswordForm(page, username, password)
+
+    await wait(100)
 
     await assertUserLogin(username)
 

--- a/test/registration.spec.ts
+++ b/test/registration.spec.ts
@@ -5,6 +5,7 @@ import {
   fillUsernamePasswordForm,
   getMnemonic,
   getMnemonicConfirmationElements,
+  logout,
 } from './test-utils/account'
 import { sendFunds } from './test-utils/ethers'
 import { openExtensionOptionsPage, setSwarmExtensionId } from './test-utils/extension.util'
@@ -120,6 +121,7 @@ describe('Registration with an existing account', () => {
   })
 
   afterAll(async () => {
+    await logout()
     await page.close()
   })
 


### PR DESCRIPTION
Added global error message to the main extension window. For now, it will only show a message when the user is not logged in, to avoid confusion. Because users might be wondering why their apps are not working, but they are unaware that there is no active session. With this implementation it's easy to add other error messages later, like missing swarm extension, RPC or bee not available etc.