### PR TITLE
chore: release library 0.5.0

### DIFF
--- a/library/CHANGELOG.md
+++ b/library/CHANGELOG.md
@@ -1,25 +1,32 @@
 # Changelog
 
-## [0.3.0](https://github.com/fairDataSociety/blossom/compare/blossom-lib-v0.2.2...blossom-lib-v0.3.0) (2023-04-25)
+## [0.5.0](https://github.com/fairDataSociety/blossom/compare/blossom-lib-v0.3.0...blossom-lib-v0.5.0) (2023-09-31)
 
+### Features
+
+- add option to retrieve user's address
+
+## [0.3.0](https://github.com/fairDataSociety/blossom/compare/blossom-lib-v0.2.2...blossom-lib-v0.3.0) (2023-04-25)
 
 ### Bug Fixes
 
-* serialization [#130](https://github.com/fairDataSociety/blossom/issues/130) ([#131](https://github.com/fairDataSociety/blossom/issues/131)) ([12dfca3](https://github.com/fairDataSociety/blossom/commit/12dfca3b8176f3ba3bacfe28a4bd61fb22715550))
+- serialization [#130](https://github.com/fairDataSociety/blossom/issues/130)
+  ([#131](https://github.com/fairDataSociety/blossom/issues/131))
+  ([12dfca3](https://github.com/fairDataSociety/blossom/commit/12dfca3b8176f3ba3bacfe28a4bd61fb22715550))
 
 ## [0.2.2](https://github.com/fairDataSociety/blossom/compare/blossom-lib-v0.2.1...blossom-lib-v0.2.2) (2023-03-01)
 
-
 ### Bug Fixes
 
-* buffer serialization ([#114](https://github.com/fairDataSociety/blossom/issues/114)) ([1616fd1](https://github.com/fairDataSociety/blossom/commit/1616fd1a06ed8fdb2bd44f4eabd8d8357fe437d7))
+- buffer serialization ([#114](https://github.com/fairDataSociety/blossom/issues/114))
+  ([1616fd1](https://github.com/fairDataSociety/blossom/commit/1616fd1a06ed8fdb2bd44f4eabd8d8357fe437d7))
 
 ## [0.2.1](https://github.com/fairDataSociety/blossom/compare/blossom-lib-v0.2.0...blossom-lib-v0.2.1) (2023-02-23)
 
-
 ### Bug Fixes
 
-* compatibility with new fdp-storage ([#111](https://github.com/fairDataSociety/blossom/issues/111)) ([055581d](https://github.com/fairDataSociety/blossom/commit/055581dff51ba8b5a15bc758b73faa23c6f3efa5))
+- compatibility with new fdp-storage ([#111](https://github.com/fairDataSociety/blossom/issues/111))
+  ([055581d](https://github.com/fairDataSociety/blossom/commit/055581dff51ba8b5a15bc758b73faa23c6f3efa5))
 
 ## [0.2.0](https://github.com/fairDataSociety/blossom/compare/blossom-lib-v0.1.0...blossom-lib-v0.2.0) (2023-01-16)
 

--- a/library/package-lock.json
+++ b/library/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fairdatasociety/blossom",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fairdatasociety/blossom",
-      "version": "0.3.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@fairdatasociety/fdp-storage": "^0.11.0"

--- a/library/package.json
+++ b/library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fairdatasociety/blossom",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "description": "JavaScript library for interaction with the Blossom browser extension",
   "main": "build/index.js",
   "scripts": {


### PR DESCRIPTION
The release please plugin is not working again, so it couldn't parse the commits. So the release PR must be created manually.